### PR TITLE
Always reset addrlen argument to correct struct size before recvfrom

### DIFF
--- a/axdigi.c
+++ b/axdigi.c
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
     int size, rt;
     char buf[4096];
     struct sockaddr sa;
-    socklen_t asize=sizeof(sa);
+    socklen_t asize;
 
     /* Check our huge range of flags */
     if (argc > 1)
@@ -83,6 +83,7 @@ int main(int argc, char *argv[])
 
     while(1)
     {
+        asize = sizeof(sa);
         if ((size = recvfrom(skt, buf, sizeof(buf), 0, &sa, &asize)) == -1)
         {
             perror("recv");


### PR DESCRIPTION
Machine: Raspberry Pi 2 with recent Raspbian (linux 4.9.24-v7+)

I've been having issues with destination callsigns being corrupt from the second packet onward. I noticed that the docs for recvfrom say that addrlen should be reset to the full size of src_addr before each call. With that change in place I'm now getting correct decoding every time.

73, Tom VK7NTK